### PR TITLE
Fix SSRFrog main container error

### DIFF
--- a/lab/ssrf/SSRFrog/src/package.json
+++ b/lab/ssrf/SSRFrog/src/package.json
@@ -2,7 +2,7 @@
   "name": "ssrfrog",
   "version": "0.0.0",
   "scripts": {
-    "start": "./bin/www"
+    "start": "sh ./bin/www"
   },
   "dependencies": {
     "express": "^4.17.1"


### PR DESCRIPTION
It said 'sh: 1: ./bin/www: not found' but it's there.
Don't know why but adding 'sh' in front of that helps.
(Even though there were already shebang in ./bin/www. Oh well)