### PR TITLE
fix: `pickle` lab can‘t respond

### DIFF
--- a/lab/deserialization/pickle/main.py
+++ b/lab/deserialization/pickle/main.py
@@ -29,7 +29,7 @@ def login():
     user = base64.b64encode(pickle.dumps({
         "name": request.form.get('name'),
         "age": int(request.form.get('age'))
-    }))
+    })).decode('utf-8')
     resp = make_response(redirect('/'))
     resp.set_cookie("session", user)
     return resp


### PR DESCRIPTION
It'would report a TypeError when I built it now
### Python Module Version
```
Python 3.8.20
Flask 2.2.5
Werkzeug 3.0.6
```

### Reproduction method
1. `docker compose up --build --force-recreate` under `lab/deserialization/pickle`
2. Acess `http://127.0.0.1:8600`
3. Type `admin` in Name field and `23` in Age field
4. Error:
```
pickle-1     | [2024-11-10 00:31:13,657] ERROR in app: Exception on /login [POST]
pickle-1     | Traceback (most recent call last):
pickle-1     |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2529, in wsgi_app
pickle-1     |     response = self.full_dispatch_request()
pickle-1     |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1825, in full_dispatch_request
pickle-1     |     rv = self.handle_user_exception(e)
pickle-1     |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1823, in full_dispatch_request
pickle-1     |     rv = self.dispatch_request()
pickle-1     |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1799, in dispatch_request
pickle-1     |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
pickle-1     |   File "/app/./main.py", line 34, in login
pickle-1     |     resp.set_cookie("session", user)
pickle-1     |   File "/usr/local/lib/python3.8/site-packages/werkzeug/sansio/response.py", line 227, in set_cookie
pickle-1     |     dump_cookie(
pickle-1     |   File "/usr/local/lib/python3.8/site-packages/werkzeug/http.py", line 1322, in dump_cookie
pickle-1     |     if not _cookie_no_quote_re.fullmatch(value):
pickle-1     | TypeError: cannot use a string pattern on a bytes-like object
```

### My Solution
Decode to convert `user` from `bytes` back to `str`
### Alternative Solution
Specify a specific version of uwsgi-nginx-flask image
Or Other...
### Note
The reason may be that the old version is accommodating or supports this syntax?
### External Link
[Python 3.8](https://docs.python.org/3.8/whatsnew/changelog.html)
[API — Flask Documentation (2.2.x)](https://web.archive.org/web/20240820134041/https://flask.palletsprojects.com/en/2.2.x/api/)
[Latest Stable Documentation](https://flask.palletsprojects.com/en/stable/api/#flask.Response.set_cookie)
[tiangolo/uwsgi-nginx-flask](https://hub.docker.com/r/tiangolo/uwsgi-nginx-flask/)